### PR TITLE
FXTab url location update fix

### DIFF
--- a/webfx-browser/src/main/java/webfx/browser/BrowserFXController.java
+++ b/webfx-browser/src/main/java/webfx/browser/BrowserFXController.java
@@ -195,9 +195,9 @@ public class BrowserFXController implements TabManager {
                 browserTab.getNavigationContext().goTo(url);
                 selectionTab.getSelectedItem().contentProperty().bind(browserTab.contentProperty());
                 browserMap.put(selectionTab.getSelectedIndex(), browserTab);
-                if(!urlField.isFocused()){
+//                if(!urlField.isFocused()){
                     urlField.textProperty().bind(browserTab.locationProperty());
-                }
+//                }
                 stopButton.disableProperty().set(!browserTab.isStoppable());
                 selectionTab.getSelectedItem().textProperty().bind(browserTab.titleProperty());
             }

--- a/webfx-browser/src/main/java/webfx/browser/tabs/FXTab.java
+++ b/webfx-browser/src/main/java/webfx/browser/tabs/FXTab.java
@@ -58,7 +58,6 @@ import java.util.Locale;
  */
 class FXTab extends BrowserTab {
 
-    private final ReadOnlyStringWrapper locationProperty = new ReadOnlyStringWrapper();
     private final SimpleObjectProperty<Node> contentProperty = new SimpleObjectProperty<>();
     private final WebFXRegion webfx;
 
@@ -85,7 +84,7 @@ class FXTab extends BrowserTab {
 
     @Override
     public ReadOnlyStringProperty locationProperty() {
-        return locationProperty;
+        return webfx.urlProperty();
     }
 
     @Override


### PR DESCRIPTION
Currently, WebFX browser does not update URL 
location textfield for FXML pages (it works only for HTML). 
This patch fixes it.
 (one guy pointed it to me at one of my presentations and I fixed it before FOSDEM)  