### PR TITLE
Fix for unnecessary opening HTML content in a new tab.

### DIFF
--- a/webfx-browser/src/main/java/webfx/browser/tabs/HTMLTab.java
+++ b/webfx-browser/src/main/java/webfx/browser/tabs/HTMLTab.java
@@ -60,6 +60,7 @@ import org.w3c.dom.events.Event;
 import org.w3c.dom.events.EventTarget;
 import org.w3c.dom.html.HTMLAnchorElement;
 import webfx.NavigationContext;
+import webfx.URLVerifier;
 import webfx.browser.BrowserTab;
 import webfx.browser.TabManager;
 import webfx.contentdescriptors.ContentDescriptor;
@@ -93,19 +94,19 @@ class HTMLTab extends BrowserTab {
                     n.addEventListener("click", (Event event) -> {
                         EventTarget eventTarget = event.getTarget();
 
-                        if (eventTarget instanceof HTMLAnchorElement == false) {
+                        if (!(eventTarget instanceof HTMLAnchorElement)) {
                             return;
                         }
 
                         HTMLAnchorElement hrefObj = (HTMLAnchorElement) event.getTarget();
-                        final String href = hrefObj.getHref();
-                        if (Arrays.stream(getContentDescripor().getFileExtensions()).filter(s -> !href.endsWith(s)).count() > 0) {
-                            try {
-                                getTabManager().openInNewTab(new URL(href));
-                            } catch (MalformedURLException ex) {
-                                Logger.getLogger(HTMLTab.class.getName()).log(Level.SEVERE, null, ex);
+                        try {
+                            final URL href = new URL(hrefObj.getHref());
+                            if (new URLVerifier(href).getContentDescriptor() != ContentDescriptor.HTML.instance()) {
+                                getTabManager().openInNewTab(href);
+                                event.preventDefault();
                             }
-                            event.preventDefault();
+                        } catch (MalformedURLException ex) {
+                            Logger.getLogger(HTMLTab.class.getName()).log(Level.SEVERE, null, ex);
                         }
                     }, true);
                 }

--- a/webfx-component/src/main/java/webfx/URLVerifier.java
+++ b/webfx-component/src/main/java/webfx/URLVerifier.java
@@ -59,6 +59,8 @@ import org.apache.http.client.utils.URIUtils;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.impl.client.LaxRedirectStrategy;
+import webfx.contentdescriptors.ContentDescriptor;
+import webfx.contentdescriptors.ContentDescriptorsRegistry;
 
 /**
  *
@@ -226,6 +228,10 @@ public class URLVerifier {
 
     public Optional<String> getContentType() {
         return Optional.ofNullable(contentType);
+    }
+
+    public ContentDescriptor getContentDescriptor() {
+        return ContentDescriptorsRegistry.getContentDescriptor(fileExtension, contentType);
     }
 
 }

--- a/webfx-component/src/main/java/webfx/urlhandlers/URLHandlersRegistry.java
+++ b/webfx-component/src/main/java/webfx/urlhandlers/URLHandlersRegistry.java
@@ -79,10 +79,7 @@ public class URLHandlersRegistry {
 
             @Override
             public Result handle(URL url) {
-                URLVerifier urlVerifier = new URLVerifier(url);
-                String fileExtension = urlVerifier.getFileExtension().orElse(null);
-                String contentType = urlVerifier.getContentType().orElse(null);
-                return new Result(ContentDescriptorsRegistry.getContentDescriptor(fileExtension, contentType), null);
+                return new Result(new URLVerifier(url).getContentDescriptor(), null);
             }
         });
 


### PR DESCRIPTION
Now, if an HTML page has a link to HTML page which URL does not end with .html, .htm, 
new HTMLTab is opened that looks very weird.
For instance all pages of fosdem.org have no extensions at all, so if you try to browse them then you get a new tab for each(!) click on a link.
This patch fixes it.